### PR TITLE
DEV: reuse plugin outlet instead of component directly

### DIFF
--- a/javascripts/discourse/components/sidebar-left-footer.hbs
+++ b/javascripts/discourse/components/sidebar-left-footer.hbs
@@ -1,5 +1,5 @@
 <footer>
-  <SidebarThemeToggle />
+  <PluginOutlet @name="sidebar-footer-actions" />
   <ul class="footer__links">
     {{#each footerLinks as |link|}}
       <li>


### PR DESCRIPTION
As soon as I installed the theme I got an error due to `SidebarThemeToggle` component not being installed, since the default sidebar isn't used at all... might just be better to reuse the existing plugin outlet. This way it will avoid errors if it's not present. 

Another option would be to include it on install by adding it in the about.json, for example: https://github.com/discourse/discourse-air/blob/main/about.json#L5C14-L5C14