### PR TITLE
FIX: Docs topic container width

### DIFF
--- a/scss/discourse/docs.scss
+++ b/scss/discourse/docs.scss
@@ -58,6 +58,8 @@
       padding: 0;
     }
     .docs-topic {
+      width: 100%;
+      padding-right: 0.5rem;
       .docs-nav-link {
         &.more {
           padding: 1rem;


### PR DESCRIPTION
Fixes a problem with the topic content appearing too narrow for docs.

![image](https://github.com/user-attachments/assets/af50fa57-f3f5-45d7-b239-90a6b1e9b2ee)

https://meta.discourse.org/t/docs-plugin-text-width-is-far-to-narrow-to-be-usable/320951