### PR TITLE
UX: remove redundant login button from profile block

### DIFF
--- a/javascripts/discourse/components/blocks/profile.gjs
+++ b/javascripts/discourse/components/blocks/profile.gjs
@@ -102,14 +102,6 @@ export default class BlockProfile extends Component {
             <span>{{i18n "js.edit"}}</span>
           </LinkTo>
         </div>
-      {{else}}
-        <div class="block block-profile">
-          <div class="block-profile__login">
-            <button class="btn" type="button">
-              Login
-            </button>
-          </div>
-        </div>
       {{/if}}
     </div>
   </template>


### PR DESCRIPTION
Removes this block for logged-out users, we already have a nearby login button so it's simply redundant 

before:
![login-btn](https://github.com/user-attachments/assets/1d67b63e-f780-42d6-b192-0052b325f27a)

after (it's gone): 
![image](https://github.com/user-attachments/assets/6a675468-0432-4179-9bbd-5d0b6c6522f9)
