### PR TITLE
UX: fix topic list dropdown on category routes

### DIFF
--- a/javascripts/discourse/connectors/after-create-topic-button/discovery-breadcrumbs.gjs
+++ b/javascripts/discourse/connectors/after-create-topic-button/discovery-breadcrumbs.gjs
@@ -85,10 +85,9 @@ class TopicFilter extends Component {
 
   @action
   filterTopics(event) {
-    const routeType = this.args.routeType;
     const category = this.router?.currentRoute?.attributes?.category;
 
-    if (routeType === "category" && event.target.value !== "categories") {
+    if (category && event.target.value !== "categories") {
       this.router.transitionTo(
         `/c/${category.slug}/${category.id}/l/${event.target.value}`
       );


### PR DESCRIPTION
These filters were always returning to the root because `routeType` was undefined — fortunately that bit is unnecessary and we can just check for the category. With this update filtering within a category will properly keep you within the category.

![image](https://github.com/user-attachments/assets/ba209a22-adca-4ff7-883b-e812292bb870)
