### PR TITLE
UX: hide footer nav in full-page mobile chat routes

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -24,3 +24,11 @@
 .topic-title-outlet.back {
   display: none;
 }
+
+// hide footer nav on mobile chat routes to maximize chat space
+
+body.has-full-page-chat {
+  .sidebar-wrapper {
+    display: none;
+  }
+}


### PR DESCRIPTION
This prevents the footer nav from covering the chat input... we want as much space as possible in the chat routes 


before: 
![image](https://github.com/user-attachments/assets/20cbacca-caa6-4f0a-9493-9506e07ffbf0)


after:
![image](https://github.com/user-attachments/assets/44d6e4bd-9d58-496c-bc22-d13f8210036a)
