### PR TITLE
FIX: Import scroll modifier correctly

### DIFF
--- a/javascripts/discourse/components/sticky-sidebar.gjs
+++ b/javascripts/discourse/components/sticky-sidebar.gjs
@@ -4,6 +4,7 @@ import { concat } from "@ember/helper";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { htmlSafe } from "@ember/template";
+import scroll from "../modifiers/scroll";
 
 function isTopInView(element, yOffset) {
   const rect = element.getBoundingClientRect();


### PR DESCRIPTION
Followup to 0e9f215bbbd9c1fd5f8f20bb34b37d1830c3a7f3

This wasn't picked up by linting because `scroll` is also a valid global on the window object.