### PR TITLE
DEV: update deprecated icon name in stylesheet

### DIFF
--- a/scss/discourse/header.scss
+++ b/scss/discourse/header.scss
@@ -189,11 +189,11 @@
   }
 
   li {
-    > .btn .d-icon, // default button 
+    > .btn .d-icon, // default button
     > svg {
       height: 0.75em;
     }
-    > .btn .d-icon-far-edit {
+    > .btn .d-icon-far-pen-to-square {
       height: 0.6em; // more consistent edit icon size
     }
   }


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names in the stylesheet. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.