### PR TITLE
UX: make leaderboard ID configurable

### DIFF
--- a/javascripts/discourse/components/blocks/top-contributors.gjs
+++ b/javascripts/discourse/components/blocks/top-contributors.gjs
@@ -42,7 +42,9 @@ export default class TopContributors extends Component {
 
   async fetchTopContributors() {
     try {
-      const data = await ajax(`/leaderboard/7.json?period=${this.period}`);
+      const data = await ajax(
+        `/leaderboard/${settings.leaderboard_id}.json?period=${this.period}`
+      );
       this.topContributors = data.users.slice(0, this.count);
     } catch {
       const data = await ajax(
@@ -126,7 +128,9 @@ export default class TopContributors extends Component {
       </ol>
 
       <div class="block-chart__expand">
-        <a href="/leaderboard/7&period={{this.period}}">
+        <a
+          href="/leaderboard/{{settings.leaderboard_id}}&period={{this.period}}"
+        >
           {{i18n "js.show_more"}}
         </a>
       </div>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   theme_metadata:
     description: ""
+    settings:
+      leaderboard_id: "Leaderboard to display when the <a href='https://meta.discourse.org/t/discourse-gamification/225916'>Discourse Gamification</a> plugin is installed. The ID can be found in the leaderboard's URL."
   user:
     view_your_profile: "View your profile"
   post:

--- a/settings.yml
+++ b/settings.yml
@@ -3,6 +3,10 @@ topic_list_show_usernames:
   type: bool
   required: true
 
+leaderboard_id:
+  default: 7
+  type: integer
+
 blocks:
   default:
     [


### PR DESCRIPTION
This leaderboard ID should not be static, so admins can customize it. 