### PR TITLE
UX: fix general style regressions

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -32,3 +32,10 @@ body.has-full-page-chat {
     display: none;
   }
 }
+
+.topic-footer-main-buttons {
+  .create,
+  .btn {
+    border-radius: var(--rounded-full);
+  }
+}

--- a/scss/discourse/d-menu.scss
+++ b/scss/discourse/d-menu.scss
@@ -1,31 +1,43 @@
 :root {
-  --shadow-menu-panel: 0 0.25rem 2rem rgba(0, 0, 0, 0.1);
+  --shadow-menu-panel: 0 0.25rem 2rem rgba(0 0 0 / 10%);
 }
 
 .fk-d-button-tooltip {
   &:has(#create-topic) {
-    display: none;
+    display: none !important;
   }
+}
+
+.topic-list-layout-trigger,
+.topic-drafts-menu-trigger {
+  display: none;
 }
 
 .fk-d-menu {
   z-index: 1000;
+
   &__inner-content {
     background: var(--neutral-100);
     border: 0;
     border-radius: var(--rounded-md);
+
     & > ul {
-      list-style: none;
-      margin: 0;
-      padding: 0.5rem 0;
       display: flex;
       flex-direction: column;
+
+      margin: 0;
+      padding: 0.5rem 0;
+
+      list-style: none;
+
       & > li {
         display: flex;
+
         a {
+          @include hover;
+
           width: 100%;
           padding: 0.5rem 1rem;
-          @include hover;
         }
       }
     }

--- a/scss/discourse/topic.scss
+++ b/scss/discourse/topic.scss
@@ -1,16 +1,21 @@
 #topic-title {
   display: flex;
-  border-bottom: var(--border-inner);
-  padding: 1rem;
-  margin: 0;
   gap: 2.15rem;
+
+  margin: 0;
+  padding: 1rem;
+
+  border-bottom: var(--border-inner);
+
+  &::before,
+  &::after {
+    content: unset;
+  }
+
   .title-wrapper {
     row-gap: 0.25rem;
   }
-  &:before,
-  &:after {
-    content: unset;
-  }
+
   h1 {
     @include headline-small;
 
@@ -18,6 +23,7 @@
       color: var(--neutral-10);
     }
   }
+
   .topic-title-outlet {
     order: -1;
   }
@@ -34,43 +40,53 @@
 
   .post-infos {
     display: contents;
-    .reply-to-tab {
-      width: 100%;
-      order: 10;
-      color: var(--neutral-30);
-      margin: 0.25rem 0 0 0;
-      max-width: unset;
 
+    .reply-to-tab {
       @include body-small;
+
+      order: 10;
+
+      width: 100%;
+      max-width: unset;
+      margin: 0.25rem 0 0;
+
+      color: var(--neutral-30);
+
       .avatar {
         width: 1rem;
         height: 1rem;
         margin: 0 0.25rem;
       }
+
       span {
         color: var(--primary-30);
       }
+
       &:hover {
         span {
           text-decoration: underline;
         }
       }
     }
+
     .post-info {
+      @include body-small;
+
       &.post-date {
         order: 2;
       }
 
       &.edits {
         display: inline-flex;
-        order: 3;
         align-self: center;
+        order: 3;
 
         .widget-button {
           @include body-small;
-          padding: 0;
+
           height: unset;
           margin-left: 0.5em;
+          padding: 0;
           font-size: var(--font-up-1);
 
           span {
@@ -78,7 +94,7 @@
           }
         }
       }
-      @include body-small;
+
       a {
         color: var(--neutral-30);
       }
@@ -87,64 +103,63 @@
 
   .names {
     display: contents;
+
     div.customer-flair-wrapper {
       order: 5;
       width: 100%;
+
       .customer-flair {
-        margin: 0;
-        height: 1.25rem;
+        display: inline-flex;
         align-items: center;
+
+        height: 1.25rem;
+        margin: 0;
         padding: 0 0.5rem;
+
         border: 0;
         border-radius: var(--rounded-full);
-        display: inline-flex;
       }
     }
+
     span {
+      @include body-small;
+
       margin: 0;
       color: var(--neutral-50);
-      @include body-small;
+
       &.first {
+        margin-right: 0.5rem;
+
         a {
           @include label-large;
+
           color: var(--neutral-10);
         }
-        margin-right: 0.5rem;
       }
+
       &.second {
         @include body-small;
+
         order: 1;
+
+        &::after {
+          content: "\00a0·\00a0";
+        }
+
         a {
           color: var(--neutral-30);
         }
-        &:after {
-          content: "\00a0·\00a0";
-        }
       }
+
       &.user-title {
-        color: var(--neutral-50);
         order: 9;
         width: 100%;
+        color: var(--neutral-50);
       }
     }
+
     .svg-icon-title {
       font-size: var(--font-up-1);
-    }
-  }
-}
-
-.small-action {
-  border-bottom: var(--border-inner);
-  &.topic-post-visited {
-    .topic-post-visited-line {
-      border: 0;
-      padding: 1rem;
-      @include body-medium;
-      color: var(--neutral-50);
-      span.topic-post-visited-message {
-        background: none;
-        color: inherit;
-      }
     }
   }
 }
@@ -161,6 +176,7 @@
   .timeline-controls {
     margin-top: 1em;
   }
+
   & > .row {
     border-right: var(--border-inner);
   }
@@ -172,41 +188,54 @@
 
   article.onscreen-post {
     .row {
-      padding: 1rem;
       column-gap: 1rem;
+      padding: 1rem;
+
       .topic-avatar {
-        position: sticky;
-        top: calc(
-          var(--header-offset) + 1rem
-        ) !important; // why is sticky conditional?
-        float: unset;
-        border: 0;
-        padding: 0;
-        width: unset;
-        margin: 0;
         @include breakpoint(tablet) {
           position: relative;
           top: unset !important;
         }
+
+        position: sticky;
+        top: calc(
+          var(--header-offset) + 1rem
+        ) !important; // why is sticky conditional?
+
+        float: unset;
+
+        width: unset;
+        margin: 0;
+        padding: 0;
+
+        border: 0;
       }
+
       .topic-body {
+        float: unset;
+        flex: 1;
+
+        width: unset;
+        padding-top: 0;
+
+        border: 0;
+
         &.highlighted {
           animation: none;
         }
-        flex: 1;
-        border: 0;
-        width: unset;
-        float: unset;
-        padding-top: 0;
+
         .topic-meta-data {
           padding: 0;
         }
+
         .regular.contents {
           margin-top: 1rem;
         }
+
         .cooked {
-          padding: 0;
           @include body-large;
+
+          padding: 0;
         }
       }
     }
@@ -214,31 +243,53 @@
 }
 
 .post-notice {
+  gap: 1rem;
+
+  max-width: unset;
   padding: 1rem;
+
+  border: 0;
+  border-bottom: var(--border-inner);
+
+  &::before {
+    padding: 0 0.875rem;
+  }
+
   p {
     @include body-medium;
   }
-  &:before {
-    padding: 0 0.875rem;
-  }
-  border: 0;
-  border-bottom: var(--border-inner);
+
   &.old {
     color: inherit;
   }
-  gap: 1rem;
-  max-width: unset;
 }
 
 .small-action {
+  gap: 1rem;
   padding: 1rem;
   border-top: 0;
-  gap: 1rem;
+  border-bottom: var(--border-inner);
+
+  &.topic-post-visited {
+    .topic-post-visited-line {
+      @include body-medium;
+
+      padding: 1rem;
+      color: var(--neutral-50);
+      border: 0;
+
+      span.topic-post-visited-message {
+        color: inherit;
+        background: none;
+      }
+    }
+  }
 
   .small-action-buttons {
     button {
-      transition: none;
       @include button($style: tertiary);
+
+      transition: none;
     }
   }
 
@@ -249,27 +300,29 @@
   }
 
   .topic-avatar {
-    width: 3rem;
     align-self: unset;
+    width: 3rem;
   }
 
   .small-action-desc {
+    @include body-medium;
+
     display: flex;
     flex-wrap: nowrap;
+    color: var(--neutral-30);
+
     .avatar {
       margin: 0;
     }
+
     .small-action-buttons {
       display: flex;
     }
-    @include body-medium;
-
-    color: var(--neutral-30);
 
     .small-action-contents {
       display: flex;
-      align-items: center;
       gap: 0.5rem;
+      align-items: center;
     }
 
     p {
@@ -281,22 +334,25 @@
 .regular {
   .more-topics {
     &__container {
-      padding: 1em;
       max-width: unset;
+      padding: 1em;
     }
+
     &__list-title {
       @include title-medium;
     }
+
     &__browse-more {
-      padding: 1rem;
       @include body-medium;
+
       margin: 0;
+      padding: 1rem;
     }
   }
 }
 
 #topic-footer-buttons {
-  padding-left: 1rem;
+  padding-inline: 1rem;
 }
 
 .topic-status-info,
@@ -315,8 +371,8 @@
 
 .topic-map.--op,
 .topic-map.--bottom {
-  padding-left: 1rem;
   padding-right: 1rem;
+  padding-left: 1rem;
 }
 
 .topic-map.--bottom {
@@ -325,16 +381,18 @@
 
 .topic-map .topic-link {
   padding: 0;
-  &:after {
+
+  &::after {
     display: none;
   }
 }
 
 .topic-back-button {
   margin-left: 0.85rem;
+
   .d-icon {
-    color: var(--neutral-30);
     padding-top: 0.5rem; // vertical alignment
+    color: var(--neutral-30);
   }
 }
 
@@ -370,12 +428,13 @@ nav.post-controls .actions button.d-hover {
 }
 
 .double-button {
-  border-radius: var(--rounded-full);
   @include hover;
+
+  border-radius: var(--rounded-full);
 
   button.d-hover,
   button:hover {
-    &:after {
+    &::after {
       display: none; // undoes the global hover effect
     }
   }
@@ -405,6 +464,7 @@ nav.post-controls .actions .double-button:hover button {
   > div {
     margin-bottom: 0;
   }
+
   .reply .row {
     padding-left: 0.5rem;
   }

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -5,22 +5,20 @@ html {
 
 html,
 body {
-  background-color: var(--neutral-100);
   @include breakpoint(tablet) {
     background-color: var(--neutral-95);
   }
+
+  background-color: var(--neutral-100);
 }
 
 :root {
   --d-max-width: 84rem;
   --wrap-px: 1rem;
-
   --column-navigation-mini: 5rem;
   --column-blocks: 19rem;
-
   --column-navigation: minmax(0, 19rem);
   --column-content: minmax(24rem, 1fr);
-
   --mobile-nav-h: 4.5rem;
 }
 
@@ -39,22 +37,27 @@ body {
 
     &:not(:has(.blocks.--right)) {
       #main-outlet-wrapper {
+        --column-content: minmax(45rem, 1fr);
+
         @include breakpoint(large) {
           grid-template-columns: var(--column-navigation-mini) minmax(0, 1fr);
           column-gap: 0;
           padding-right: 0;
           padding-left: 0;
         }
+
         @include breakpoint(tablet) {
           grid-template-areas: "content";
           grid-template-columns: 1fr;
         }
-        #main-outlet {
-          margin-right: 0rem;
-        }
-        --column-content: minmax(45rem, 1fr);
+
         grid-template-areas: "navigation content";
         grid-template-columns: var(--column-navigation) var(--column-content);
+
+        #main-outlet {
+          margin-right: 0;
+        }
+
         .blocks {
           display: none;
         }
@@ -79,7 +82,6 @@ body {
         grid-template-areas: "content";
         grid-template-columns: 1fr;
         padding: 0;
-
         padding-bottom: calc(
           var(--mobile-nav-h) + env(safe-area-inset-bottom) + 2rem
         );
@@ -89,20 +91,20 @@ body {
         }
       }
 
+      @include breakpoint(large) {
+        padding-left: 0;
+      }
+
       display: grid;
       grid-template-areas: "navigation content blocks";
       grid-template-columns: var(--column-navigation) var(--column-content) var(
           --column-blocks
         );
-      margin: 0 auto;
       column-gap: 2rem;
 
       box-sizing: border-box;
+      margin: 0 auto;
       padding: 0 var(--wrap-px) 0;
-
-      @include breakpoint(large) {
-        padding-left: 0;
-      }
 
       .sticky-sidebar {
         display: unset;
@@ -117,21 +119,24 @@ body {
       }
 
       #main-outlet {
-        background: var(--neutral-100);
-        margin-top: 2rem;
-        margin-bottom: 2rem;
         @include breakpoint(large) {
           margin-top: 1rem;
         }
+
         @include breakpoint(tablet) {
           margin: 0;
           border: 0;
           border-radius: 0;
         }
-        padding: 0;
-        grid-area: content;
 
+        grid-area: content;
         align-self: flex-start;
+
+        margin-top: 2rem;
+        margin-bottom: 2rem;
+        padding: 0;
+
+        background: var(--neutral-100);
         border: var(--border-outer);
         border-radius: var(--rounded-lg);
       }
@@ -149,8 +154,8 @@ body {
 
   &.admin-interface {
     #main-outlet-wrapper #main-outlet {
-      padding-left: 1rem;
       padding-right: 1rem;
+      padding-left: 1rem;
     }
   }
 }
@@ -159,8 +164,10 @@ body {
   [class*="user-"] {
     &[class*="-page"] {
       #main-outlet-wrapper #main-outlet {
-        padding-left: 1rem;
+        box-sizing: border-box;
+        max-width: 100vw;
         padding-right: 1rem;
+        padding-left: 1rem;
       }
     }
   }


### PR DESCRIPTION
This addresses general regressions reported in https://meta.discourse.org/t/discourse-central-theme-meta-pre-release-out-now/287495, including:

incorrectly placed buttons: 
![image](https://github.com/user-attachments/assets/48c354a5-6b28-4dd9-a3cb-ae798a68072a)

missing right padding in topic footer button: 
![image](https://github.com/user-attachments/assets/9ce61671-b9b3-446e-992f-bd779697c89c)


broken user profile layout: 
![image](https://github.com/user-attachments/assets/83e853b7-8d27-4d99-92e4-62ba67b368d8)

I've also applies some stylelint autofixes in the edited files 